### PR TITLE
fix: baseUrl for deployment to github pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: "TechFellows",
   tagline: "Build for Web",
   url: "https://techfellows.github.io",
-  baseUrl: "/",
+  baseUrl: "/website/",
   onBrokenLinks: "throw",
   favicon: "img/techfellows.jpg",
   organizationName: "techfellows", // Usually your GitHub org/user name.


### PR DESCRIPTION
This will fix #9 

## Disclaimer:
Keep in mind that I am fixing the baseUrl to "/website/" (your github project's name) so, if you'd like to deploy to netlify or any other hosting alike, then it's probably that you'd need to fix it to '/' or the deep path as required.