### PR TITLE
Fix issue #22 - logo when dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -112,3 +112,7 @@
   padding: 10px;
   cursor: hand;
 }
+
+html[data-theme="dark"] .navbar__logo {
+  filter: invert(100%);
+}


### PR DESCRIPTION
Use inverted color when in darkmode

![image](https://user-images.githubusercontent.com/8109770/95266701-97e64a80-082b-11eb-99c6-5593f06922b5.png)

![image](https://user-images.githubusercontent.com/8109770/95266644-7e450300-082b-11eb-8232-dc8461e0ff0d.png)

Fix: #22  